### PR TITLE
Fix for 'Cannot invoke ... because "classPath" is null.'

### DIFF
--- a/src/main/java/net/labymod/intellij/singlehotswap/compiler/impl/BuiltInJavaCompiler.java
+++ b/src/main/java/net/labymod/intellij/singlehotswap/compiler/impl/BuiltInJavaCompiler.java
@@ -89,8 +89,11 @@ public class BuiltInJavaCompiler extends AbstractCompiler {
             File compiledFile = new File(classObject.getPath());
             FileUtil.writeToFile(compiledFile, bytes);
 
-            // Add class file to list
-            classFiles.add(ClassFile.fromClassObject(project, classObject));
+            // filter out any non-class-objects generated (e. g. files from annotation processing)
+            if (classObject.getClassName() != null) {
+                // Add class file to list
+                classFiles.add(ClassFile.fromClassObject(project, classObject));
+            }
         }
         return classFiles;
     }


### PR DESCRIPTION
Hi,

we are using annotation processing to generate mapping files for internationalisation at compile time. These are properies-files, which causes this plugin to error out, since the compile task returns the properties files along with the "normal" class files as compiler output. However, these properties files do not have a classname and thus `BuiltInJavaCompiler` throws an exception, when trying to create a `ClassFile` object. This pull request fixes this issue, so that `ClassFile`-objects are only created for actual classes. I did some debugging and can also say, that filtering out these files matches the behaviour, when checking with `HotSwapManager.scanForModifiedClasses`, so although I am not an expert in the IntelliJ-Platform and Plugin-API I think this is the correct fix for this issue.

![2023-04-19 14_23_33-Window](https://user-images.githubusercontent.com/25818034/233082818-ff54a967-f1c1-4ddd-bdb9-c8d65de539d6.png)

With this fix in place, the issue did not occur and the classes were being hotswapped, as expected.
Thanks for providing this plugin and all the best
Jonas