### PR TITLE
 Enable Debugging Information for BuiltInJavaCompiler

### DIFF
--- a/src/main/java/net/labymod/intellij/singlehotswap/compiler/impl/BuiltInJavaCompiler.java
+++ b/src/main/java/net/labymod/intellij/singlehotswap/compiler/impl/BuiltInJavaCompiler.java
@@ -48,7 +48,8 @@ public class BuiltInJavaCompiler extends AbstractCompiler {
         List<String> options = new ArrayList<>(Arrays.asList(
                 "-encoding", "UTF-8",
                 "-source", javaVersion,
-                "-target", javaVersion
+                "-target", javaVersion,
+                "-g" // Generate all debugging information
         ));
 
         // Collect dependencies


### PR DESCRIPTION
In this pull request, I've enhanced the `BuiltInJavaCompiler` component of your code. Previously, the compiler did not generate debug information, making it difficult to troubleshoot issues. To address this, I've added the `-g` flag to the compiler options, enabling the generation of debug information during the build process.

As a result, the compiled Java binaries will now include additional debugging information when using `BuiltInJavaCompiler`.